### PR TITLE
fix: resolve high severity vulnerabilities (ajv ReDoS, backend-plugin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
       "lodash": "4.17.23",
       "@backstage/cli-common": "0.1.17",
       "diff": "5.2.2",
-      "undici": "7.18.2"
+      "undici": "7.18.2",
+      "ajv": "8.18.0"
     }
   }
 }

--- a/plugins/backstage-plugin-wiz-backend/package.json
+++ b/plugins/backstage-plugin-wiz-backend/package.json
@@ -27,10 +27,10 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-defaults": "^0.13.2",
-    "@backstage/backend-plugin-api": "^1.5.0",
+    "@backstage/backend-defaults": "^0.15.1",
+    "@backstage/backend-plugin-api": "^1.6.2",
     "@backstage/config": "^1.3.6",
-    "@backstage/plugin-catalog-node": "^1.20.0",
+    "@backstage/plugin-catalog-node": "^1.20.1",
     "@backstage/types": "^1.2.2",
     "express": "4.21.2",
     "express-promise-router": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   '@backstage/cli-common': 0.1.17
   diff: 5.2.2
   undici: 7.18.2
+  ajv: 8.18.0
 
 importers:
 
@@ -157,17 +158,17 @@ importers:
   plugins/backstage-plugin-wiz-backend:
     dependencies:
       '@backstage/backend-defaults':
-        specifier: ^0.13.2
-        version: 0.13.2(@swc/core@1.15.3(@swc/helpers@0.5.17))
+        specifier: ^0.15.1
+        version: 0.15.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(better-sqlite3@12.5.0)
       '@backstage/backend-plugin-api':
-        specifier: ^1.5.0
-        version: 1.5.0(pg@8.16.3)
+        specifier: ^1.6.2
+        version: 1.6.2(better-sqlite3@12.5.0)(pg@8.16.3)
       '@backstage/config':
         specifier: ^1.3.6
         version: 1.3.6
       '@backstage/plugin-catalog-node':
-        specifier: ^1.20.0
-        version: 1.20.0(pg@8.16.3)
+        specifier: ^1.20.1
+        version: 1.20.1(better-sqlite3@12.5.0)(pg@8.16.3)
       '@backstage/types':
         specifier: ^1.2.2
         version: 1.2.2
@@ -186,7 +187,7 @@ importers:
         version: 1.10.0(@swc/core@1.15.3(@swc/helpers@0.5.17))
       '@backstage/cli':
         specifier: ^0.34.5
-        version: 0.34.5(@module-federation/enhanced@0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(@types/express@4.17.25)(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(terser-webpack-plugin@5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))(typescript@5.9.3)(webpack-dev-server@5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+        version: 0.34.5(@module-federation/enhanced@0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(@types/express@4.17.25)(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(terser-webpack-plugin@5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))(typescript@5.9.3)(webpack-dev-server@5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
       '@types/express':
         specifier: ^4.17.25
         version: 4.17.25
@@ -646,6 +647,9 @@ packages:
   '@backstage/backend-app-api@1.3.0':
     resolution: {integrity: sha512-GEwDeVtu4rWBmsAI5rbc2yfdJ1YmaxCtAr4sy8GZa8tVFt/qe3e1H3WDcXWOPZT9zXvKnBuVx09HlwOffgaH9w==}
 
+  '@backstage/backend-app-api@1.4.1':
+    resolution: {integrity: sha512-FkOlBfgriUeRCMp+fypJcz1unHWMZFALKGAcxhtoZ4pG/Bxla3o9CJ8uvSutTP+RWmABJx9dWX2fvoZ2lSLPiQ==}
+
   '@backstage/backend-defaults@0.13.2':
     resolution: {integrity: sha512-UHxExWmWG+eyXw3kVUCLJvYHw0gesWbajFTurKUiIv1wac5XKkdSavebWZ+4b+V7X4SAQQaaJEowzWc5+78N2g==}
     peerDependencies:
@@ -654,11 +658,25 @@ packages:
       '@google-cloud/cloud-sql-connector':
         optional: true
 
+  '@backstage/backend-defaults@0.15.1':
+    resolution: {integrity: sha512-5ASN4q2Khdi6eetbOldK8sCYp5DF7MM4GqC7eNd1Eowbv7kD0n+vVdMtKlUdTeiF3nCn+aeVg3K1tt2h7mA/kg==}
+    peerDependencies:
+      '@google-cloud/cloud-sql-connector': ^1.4.0
+      better-sqlite3: ^12.0.0
+    peerDependenciesMeta:
+      '@google-cloud/cloud-sql-connector':
+        optional: true
+      better-sqlite3:
+        optional: true
+
   '@backstage/backend-dev-utils@0.1.5':
     resolution: {integrity: sha512-OMCoDN2m2otZfK1nOdW4+BbPVuAY7g+IYyzfkXmVGTb8M3yi5vGxsUpfJv24K25vaz54m65xBB29bOPSjxfzag==}
 
-  '@backstage/backend-plugin-api@1.5.0':
-    resolution: {integrity: sha512-uDj+CjbR8ojmOZMK9+vfirvRQ4GmBEWcUtsmHhxsbK1kK7nrayk9l1Eq62l6RCMO9aDirOTRtrbzHJDcxNFx3w==}
+  '@backstage/backend-dev-utils@0.1.6':
+    resolution: {integrity: sha512-5TqtPyNhC4JMUdlvrhC0oOexJRCdglsOxc68IANWprNeXhVYoGyg3w/T7+XsN/iBi40a7qXJ1RNAO/hUwbLDAQ==}
+
+  '@backstage/backend-plugin-api@1.6.2':
+    resolution: {integrity: sha512-oAyaRG+pnSyQ0Wo9fLaz65BpMowuX+IeW4fyDDys+/saiA+GGvIZ9HjbOYZYWH6AvbamqdpiRCzkBVTjsV7woA==}
 
   '@backstage/backend-test-utils@1.10.0':
     resolution: {integrity: sha512-nqtAXHjmZUyaOJNjDgA89JCe/ys7PVcCWUixOXvnOXduf198nM8Qz4yQBEma/p39qQVsF5kaV27jkKCX6pMv1g==}
@@ -674,6 +692,9 @@ packages:
 
   '@backstage/cli-node@0.2.15':
     resolution: {integrity: sha512-KYWSidGanRUGAVGYFv0vcmmsn6RyL+9ZRJxzTFrLHgrou8nAE9BN4qL/yEUMGyJrIzvP0FDsxO/j/ngpHTOBNA==}
+
+  '@backstage/cli-node@0.2.17':
+    resolution: {integrity: sha512-J4rm1ZDKmYBVP6NUY1DrUKzRx/pi56YMwsu/1Gvi3Ja6ROOiKegQzlT8q3tYmPRcGgqVibXknrnbaV1Fr6J3pg==}
 
   '@backstage/cli@0.34.5':
     resolution: {integrity: sha512-taJHFGwbNQZezItKYedTSful5x04Hy3qKuO+ZSz3y5DFVZqGIMgnMqhXKb9mAiDkrdVvm3rq/vUlzFBBFlw1nw==}
@@ -710,6 +731,9 @@ packages:
 
   '@backstage/config-loader@1.10.6':
     resolution: {integrity: sha512-lzvVw4lWf/iyEJktucVK9MFJmmhkJ0N1iYcYlvZqydVSv8c7lq379ddDMPROfOWWOVT1qgxoQw2Es8O+2+55wA==}
+
+  '@backstage/config-loader@1.10.7':
+    resolution: {integrity: sha512-X/x4lBeLd6ByPv5lVa8d8TZh9INWa1mYuRzsvnchLd2oin3hL/RFH3em606Mkb/V+SdvgChpY8+h58laXvxxDA==}
 
   '@backstage/config@1.3.6':
     resolution: {integrity: sha512-aq/xPfF1+gEBhlQnCS6L+4dzPzM+pKd47AyljMOmcX1SstnK38YErNJvMg47bJOtxQhtxEW6lyZ1aIui6XO4/A==}
@@ -837,6 +861,9 @@ packages:
   '@backstage/integration@1.18.2':
     resolution: {integrity: sha512-yG+BOM1RXeuf3zddIARTqkFLL1zFIj7rTvqb6Z3WXQJD4uSJ+MW7ulDXTLWUzelAtxKd8axAj3hB3TPhblPX2A==}
 
+  '@backstage/integration@1.19.2':
+    resolution: {integrity: sha512-7Ct7vBEN6vBDdPOn3Oy9z8VV0mWZvXsW89vOEHWdtZ+TqirPpqhkTMU9vKBg9MROEmuy+rJQfuwz8yQIAojM8Q==}
+
   '@backstage/plugin-app@0.3.2':
     resolution: {integrity: sha512-OVxynhuyr3nngIgqTDy6xg/+cmm4nOREIO6fxrLUpHUvGWkIKBhKINXnFw6iKjtgOzHiVH8gieKO2NXSrfgymg==}
     peerDependencies:
@@ -848,14 +875,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@backstage/plugin-auth-node@0.6.12':
+    resolution: {integrity: sha512-UYAyKfh3DOB2Yqy+uJqHy5WRNvF8fJGSTBG25PpQBdbeMTWObeBcMXKXGILPReX0PbcRsRv+WZvfg7jylVNc9g==}
+
   '@backstage/plugin-auth-node@0.6.9':
     resolution: {integrity: sha512-PuZDqz+f1YvscjLMKMcJxg7jXZNOXsJ3J1NRBYAsQ9qeiM/1Y7w5m9Ti6Fb5h5aeduiBrN8zE+bOhwlaPMNKqQ==}
 
   '@backstage/plugin-catalog-common@1.1.7':
     resolution: {integrity: sha512-HIU99MiXvPpUbdsdNtXo+sLo+eMcePjnj8eqIZ9JAkTmod+wGV38T96cYJlyevp4tix80djz8qyuc2FjJTY5LQ==}
 
-  '@backstage/plugin-catalog-node@1.20.0':
-    resolution: {integrity: sha512-8bWxlejjzeA7gQdkvVYNNv3yXkVpjhi4TDkwWfn+0xYtgpmOhD5gfoeHUerlFodrO6cKoUDGg1Vlpvkx/C1GhA==}
+  '@backstage/plugin-catalog-node@1.20.1':
+    resolution: {integrity: sha512-EkIk1mzHL3ffOgWXN1qC7gRxbraEQalAbsYzDaa57FdGM+Dabagdx18kC0L00AkGdUxzQk1GTL7bTo8Vptua3A==}
 
   '@backstage/plugin-catalog-react@1.21.3':
     resolution: {integrity: sha512-k5EikhFehDGTjxWEwPfGtZTyO9lWQ1YRImT3sD4EAR9VZOGQXGHDGAS1u/BtslCFyyhkv6LPglkvxAXf/o1Bhg==}
@@ -871,11 +901,20 @@ packages:
   '@backstage/plugin-events-node@0.4.17':
     resolution: {integrity: sha512-DWpNwOmkSKRsZGanI8Eqy+wEpb2XhZFwLSanNbXrq5//KHKCeQU0ZxJKCybWmXIf/67ODFVkJcRZ9jMBCaVDRw==}
 
+  '@backstage/plugin-events-node@0.4.18':
+    resolution: {integrity: sha512-PHxS5X8r6cI3BglafvLL7tR7OD2axuWqj0myO/Ls58X5ZS8uplmffRuWE59t509E8MBe6fQCyO6epYWVFjvyYg==}
+
   '@backstage/plugin-permission-common@0.9.3':
     resolution: {integrity: sha512-QB9HtU4DlKyWaQFJvwiiURej1GYeMn4fB38lsVmvHuFTxraMIwEgoHjSjzdCFBBItrOUl4FILaaIZBtJGei9vA==}
 
+  '@backstage/plugin-permission-common@0.9.5':
+    resolution: {integrity: sha512-1P39g205jkiGdMb76WX4LyY0zi5I7zSSbsQbpKdRjAUMm/SH4NclSBAcaQDKxreDYASl6CGdjML1akmex0xlcQ==}
+
   '@backstage/plugin-permission-node@0.10.6':
     resolution: {integrity: sha512-yA7zZDUPEfo0P9LdvIxkudlaOygTsLEz6mFQcnvX40E7EN94Z/pKvuSGI1r1W8BWsiccS0TsBGmmv9iS5GF/5Q==}
+
+  '@backstage/plugin-permission-node@0.10.9':
+    resolution: {integrity: sha512-jc2it8GMKCVGZN4EooeFp6qUxOtIObi1hH79+8NAyg05SeAmhGOYNc2Zbc1AkPjzmtB1kxjxSL+FTG2AV095LQ==}
 
   '@backstage/plugin-permission-react@0.4.38':
     resolution: {integrity: sha512-D/lP3CcRQFAxi0jTNjSpYcnMC61+vxDehY/w2vdz/9sPf1C9D5IV/wdWn1HP42QCZPcyq+LICiPsWULUvkCyKA==}
@@ -3899,7 +3938,7 @@ packages:
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -3907,18 +3946,15 @@ packages:
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
-      ajv: ^6.9.1
+      ajv: 8.18.0
 
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
-      ajv: ^8.8.2
+      ajv: 8.18.0
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -6879,9 +6915,6 @@ packages:
     resolution: {integrity: sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==}
     engines: {node: '>=12.0.0'}
 
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -9268,6 +9301,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -9579,6 +9613,10 @@ packages:
     resolution: {integrity: sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==}
     hasBin: true
 
+  typescript-json-schema@0.67.1:
+    resolution: {integrity: sha512-vKTZB/RoYTIBdVP7E7vrgHMCssBuhja91wQy498QIVhvfRimaOgjc98uwAXmZ7mbLUytJmOSbF11wPz+ByQeXg==}
+    hasBin: true
+
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
@@ -9683,9 +9721,6 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
   uri-template@2.0.0:
     resolution: {integrity: sha512-r/i44nPoo0ktEZDjx+hxp9PSjQuBBfsd6RgCRuuMqCP0FZEp+YE0SpihThI4UGc5ePqQEFsdyZc7UVlowp+LLw==}
 
@@ -9783,6 +9818,11 @@ packages:
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
+
+  vm2@3.10.4:
+    resolution: {integrity: sha512-Gl6r7MN3mkawGurFdp467yDJQ7HdragK2QVVWFbOCd3LPJXJLE2xZFwLCNhp04MTkHruPqLIOs3pYbJQJw/1aA==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -10051,11 +10091,22 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod-validation-error@3.5.4:
     resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.24.4
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -11092,7 +11143,23 @@ snapshots:
 
   '@backstage/backend-app-api@1.3.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@backstage/backend-app-api@1.4.1(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
     transitivePeerDependencies:
@@ -11116,7 +11183,7 @@ snapshots:
       '@azure/storage-blob': 12.29.1
       '@backstage/backend-app-api': 1.3.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/backend-dev-utils': 0.1.5
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/cli-node': 0.2.15
       '@backstage/config': 1.3.6
       '@backstage/config-loader': 1.10.6(@swc/core@1.15.3(@swc/helpers@0.5.17))
@@ -11193,16 +11260,105 @@ snapshots:
       - supports-color
       - tedious
 
+  '@backstage/backend-defaults@0.15.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(better-sqlite3@12.5.0)':
+    dependencies:
+      '@aws-sdk/abort-controller': 3.374.0
+      '@aws-sdk/client-codecommit': 3.940.0
+      '@aws-sdk/client-s3': 3.940.0
+      '@aws-sdk/credential-providers': 3.940.0
+      '@aws-sdk/types': 3.936.0
+      '@azure/storage-blob': 12.29.1
+      '@backstage/backend-app-api': 1.4.1(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-dev-utils': 0.1.6
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/cli-node': 0.2.17
+      '@backstage/config': 1.3.6
+      '@backstage/config-loader': 1.10.7(@swc/core@1.15.3(@swc/helpers@0.5.17))
+      '@backstage/errors': 1.2.7
+      '@backstage/integration': 1.19.2
+      '@backstage/integration-aws-node': 0.1.19
+      '@backstage/plugin-auth-node': 0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-events-node': 0.4.18(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-permission-node': 0.10.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/types': 1.2.2
+      '@google-cloud/storage': 7.17.3
+      '@keyv/memcache': 2.0.2(keyv@5.5.4)
+      '@keyv/redis': 4.6.0(keyv@5.5.4)
+      '@keyv/valkey': 1.0.11
+      '@manypkg/get-packages': 1.1.3
+      '@octokit/rest': 19.0.13
+      '@opentelemetry/api': 1.9.0
+      '@types/cors': 2.8.19
+      '@types/express': 4.17.25
+      archiver: 7.0.1
+      base64-stream: 1.0.0
+      compression: 1.8.1
+      concat-stream: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.5
+      cron: 3.5.0
+      express: 4.22.1
+      express-promise-router: 4.1.1(@types/express@4.17.25)(express@4.22.1)
+      express-rate-limit: 7.5.1(express@4.22.1)
+      fs-extra: 11.3.2
+      git-url-parse: 15.0.0
+      helmet: 6.2.0
+      infinispan: 0.12.0
+      is-glob: 4.0.3
+      jose: 5.10.0
+      keyv: 5.5.4
+      knex: 3.1.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      lodash: 4.17.23
+      logform: 2.7.0
+      luxon: 3.7.2
+      minimatch: 9.0.5
+      mysql2: 3.15.3
+      node-fetch: 2.7.0
+      node-forge: 1.3.2
+      p-limit: 3.1.0
+      path-to-regexp: 8.3.0
+      pg: 8.16.3
+      pg-connection-string: 2.9.1
+      pg-format: 1.0.4
+      rate-limit-redis: 4.3.1(express-rate-limit@7.5.1(express@4.21.2))
+      raw-body: 2.5.3
+      selfsigned: 2.4.1
+      tar: 7.5.7
+      triple-beam: 1.4.1
+      uuid: 11.1.0
+      winston: 3.18.3
+      winston-transport: 4.9.0
+      yauzl: 3.2.0
+      yn: 4.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      better-sqlite3: 12.5.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - aws-crt
+      - bare-abort-controller
+      - encoding
+      - mysql
+      - pg-native
+      - react-native-b4a
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@backstage/backend-dev-utils@0.1.5': {}
 
-  '@backstage/backend-plugin-api@1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
+  '@backstage/backend-dev-utils@0.1.6': {}
+
+  '@backstage/backend-plugin-api@1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
       '@backstage/cli-common': 0.1.17
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
-      '@backstage/plugin-auth-node': 0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
-      '@backstage/plugin-permission-common': 0.9.3
-      '@backstage/plugin-permission-node': 0.10.6(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-auth-node': 0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-permission-common': 0.9.5
+      '@backstage/plugin-permission-node': 0.10.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/types': 1.2.2
       '@types/express': 4.17.25
       '@types/json-schema': 7.0.15
@@ -11222,14 +11378,14 @@ snapshots:
       - supports-color
       - tedious
 
-  '@backstage/backend-plugin-api@1.5.0(pg@8.16.3)':
+  '@backstage/backend-plugin-api@1.6.2(better-sqlite3@12.5.0)(pg@8.16.3)':
     dependencies:
       '@backstage/cli-common': 0.1.17
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
-      '@backstage/plugin-auth-node': 0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
-      '@backstage/plugin-permission-common': 0.9.3
-      '@backstage/plugin-permission-node': 0.10.6(pg@8.16.3)
+      '@backstage/plugin-auth-node': 0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-permission-common': 0.9.5
+      '@backstage/plugin-permission-node': 0.10.9(better-sqlite3@12.5.0)(pg@8.16.3)
       '@backstage/types': 1.2.2
       '@types/express': 4.17.25
       '@types/json-schema': 7.0.15
@@ -11253,7 +11409,7 @@ snapshots:
     dependencies:
       '@backstage/backend-app-api': 1.3.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/backend-defaults': 0.13.2(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
       '@backstage/plugin-auth-node': 0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
@@ -11311,7 +11467,7 @@ snapshots:
     dependencies:
       '@backstage/errors': 1.2.7
       '@backstage/types': 1.2.2
-      ajv: 8.17.1
+      ajv: 8.18.0
       lodash: 4.17.23
 
   '@backstage/cli-common@0.1.17':
@@ -11322,6 +11478,17 @@ snapshots:
       undici: 7.18.2
 
   '@backstage/cli-node@0.2.15':
+    dependencies:
+      '@backstage/cli-common': 0.1.17
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.2
+      '@manypkg/get-packages': 1.1.3
+      '@yarnpkg/parsers': 3.0.3
+      fs-extra: 11.3.2
+      semver: 7.7.3
+      zod: 3.25.76
+
+  '@backstage/cli-node@0.2.17':
     dependencies:
       '@backstage/cli-common': 0.1.17
       '@backstage/errors': 1.2.7
@@ -11440,6 +11607,134 @@ snapshots:
       terser-webpack-plugin: 5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(esbuild@0.25.12)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(esbuild@0.25.12))
       webpack: 5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(esbuild@0.25.12)
       webpack-dev-server: 5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))(esbuild@0.25.12))
+    transitivePeerDependencies:
+      - '@swc/wasm'
+      - '@types/express'
+      - '@types/node'
+      - babel-plugin-macros
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - node-notifier
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-hot-middleware
+
+  '@backstage/cli@0.34.5(@module-federation/enhanced@0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(@types/express@4.17.25)(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(terser-webpack-plugin@5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))(typescript@5.9.3)(webpack-dev-server@5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))':
+    dependencies:
+      '@backstage/catalog-model': 1.7.6
+      '@backstage/cli-common': 0.1.17
+      '@backstage/cli-node': 0.2.15
+      '@backstage/config': 1.3.6
+      '@backstage/config-loader': 1.10.6(@swc/core@1.15.3(@swc/helpers@0.5.17))
+      '@backstage/errors': 1.2.7
+      '@backstage/eslint-plugin': 0.2.0
+      '@backstage/integration': 1.18.2
+      '@backstage/release-manifests': 0.0.13
+      '@backstage/types': 1.2.2
+      '@manypkg/get-packages': 1.1.3
+      '@octokit/request': 8.4.1
+      '@rollup/plugin-commonjs': 26.0.3(rollup@4.53.3)
+      '@rollup/plugin-json': 6.1.0(rollup@4.53.3)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.53.3)
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.53.3)
+      '@rspack/core': 1.6.7(@swc/helpers@0.5.17)
+      '@rspack/dev-server': 1.1.4(@rspack/core@1.6.7(@swc/helpers@0.5.17))(@types/express@4.17.25)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      '@rspack/plugin-react-refresh': 1.5.3(react-refresh@0.17.0)
+      '@spotify/eslint-config-base': 15.0.0(eslint@8.57.1)
+      '@spotify/eslint-config-react': 15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@8.57.1)
+      '@spotify/eslint-config-typescript': 15.0.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)
+      '@swc/core': 1.15.3(@swc/helpers@0.5.17)
+      '@swc/helpers': 0.5.17
+      '@swc/jest': 0.2.39(@swc/core@1.15.3(@swc/helpers@0.5.17))
+      '@types/jest': 29.5.14
+      '@types/webpack-env': 1.18.8
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.49.0(eslint@8.57.1)(typescript@5.9.3)
+      '@yarnpkg/lockfile': 1.1.0
+      '@yarnpkg/parsers': 3.0.3
+      bfj: 8.0.0
+      buffer: 6.0.3
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      commander: 12.1.0
+      cross-fetch: 4.1.0
+      cross-spawn: 7.0.6
+      css-loader: 6.11.0(@rspack/core@1.6.7(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      ctrlc-windows: 2.2.0
+      esbuild: 0.25.12
+      eslint: 8.57.1
+      eslint-config-prettier: 9.1.2(eslint@8.57.1)
+      eslint-formatter-friendly: 7.0.0
+      eslint-plugin-deprecation: 3.0.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)
+      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
+      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      eslint-rspack-plugin: 4.3.0(eslint@8.57.1)
+      express: 4.22.1
+      fs-extra: 11.3.2
+      git-url-parse: 15.0.0
+      glob: 7.2.3
+      global-agent: 3.0.0
+      globby: 11.1.0
+      handlebars: 4.7.8
+      html-webpack-plugin: 5.6.5(@rspack/core@1.6.7(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      inquirer: 8.2.7(@types/node@18.19.130)
+      jest: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      jest-css-modules: 2.1.0
+      jest-environment-jsdom: 29.7.0
+      jest-runtime: 29.7.0
+      json-schema: 0.4.0
+      lodash: 4.17.23
+      minimatch: 9.0.5
+      node-stdlib-browser: 1.3.1
+      npm-packlist: 5.1.3
+      ora: 5.4.1
+      p-queue: 6.6.2
+      pirates: 4.0.7
+      postcss: 8.5.6
+      process: 0.11.10
+      raw-loader: 4.0.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      react-refresh: 0.17.0
+      recursive-readdir: 2.2.3
+      replace-in-file: 7.2.0
+      rollup: 4.53.3
+      rollup-plugin-dts: 6.3.0(rollup@4.53.3)(typescript@5.9.3)
+      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.53.3)
+      rollup-plugin-postcss: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      rollup-pluginutils: 2.8.2
+      semver: 7.7.3
+      style-loader: 3.3.4(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      sucrase: 3.35.1
+      swc-loader: 0.2.6(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      tar: 7.5.7
+      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(typescript@5.9.3)
+      ts-morph: 24.0.0
+      undici: 7.18.2
+      util: 0.12.5
+      yaml: 2.8.2
+      yargs: 16.2.0
+      yml-loader: 2.1.0
+      yn: 4.0.0
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    optionalDependencies:
+      '@module-federation/enhanced': 0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      terser-webpack-plugin: 5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
+      webpack: 5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))
+      webpack-dev-server: 5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
     transitivePeerDependencies:
       - '@swc/wasm'
       - '@types/express'
@@ -11588,134 +11883,6 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@backstage/cli@0.34.5(@module-federation/enhanced@0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(@types/express@4.17.25)(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(terser-webpack-plugin@5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))(typescript@5.9.3)(webpack-dev-server@5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))':
-    dependencies:
-      '@backstage/catalog-model': 1.7.6
-      '@backstage/cli-common': 0.1.17
-      '@backstage/cli-node': 0.2.15
-      '@backstage/config': 1.3.6
-      '@backstage/config-loader': 1.10.6(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@backstage/errors': 1.2.7
-      '@backstage/eslint-plugin': 0.2.0
-      '@backstage/integration': 1.18.2
-      '@backstage/release-manifests': 0.0.13
-      '@backstage/types': 1.2.2
-      '@manypkg/get-packages': 1.1.3
-      '@octokit/request': 8.4.1
-      '@rollup/plugin-commonjs': 26.0.3(rollup@4.53.3)
-      '@rollup/plugin-json': 6.1.0(rollup@4.53.3)
-      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.53.3)
-      '@rollup/plugin-yaml': 4.1.2(rollup@4.53.3)
-      '@rspack/core': 1.6.7(@swc/helpers@0.5.17)
-      '@rspack/dev-server': 1.1.4(@rspack/core@1.6.7(@swc/helpers@0.5.17))(@types/express@4.17.25)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      '@rspack/plugin-react-refresh': 1.5.3(react-refresh@0.17.0)
-      '@spotify/eslint-config-base': 15.0.0(eslint@8.57.1)
-      '@spotify/eslint-config-react': 15.0.0(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@5.2.0(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)))(eslint@8.57.1)
-      '@spotify/eslint-config-typescript': 15.0.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)
-      '@swc/core': 1.15.3(@swc/helpers@0.5.17)
-      '@swc/helpers': 0.5.17
-      '@swc/jest': 0.2.39(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      '@types/jest': 29.5.14
-      '@types/webpack-env': 1.18.8
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.49.0(eslint@8.57.1)(typescript@5.9.3)
-      '@yarnpkg/lockfile': 1.1.0
-      '@yarnpkg/parsers': 3.0.3
-      bfj: 8.0.0
-      buffer: 6.0.3
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      commander: 12.1.0
-      cross-fetch: 4.1.0
-      cross-spawn: 7.0.6
-      css-loader: 6.11.0(@rspack/core@1.6.7(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      ctrlc-windows: 2.2.0
-      esbuild: 0.25.12
-      eslint: 8.57.1
-      eslint-config-prettier: 9.1.2(eslint@8.57.1)
-      eslint-formatter-friendly: 7.0.0
-      eslint-plugin-deprecation: 3.0.0(eslint@8.57.1)(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)
-      eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)))(typescript@5.9.3)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-react: 7.37.5(eslint@8.57.1)
-      eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
-      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
-      eslint-rspack-plugin: 4.3.0(eslint@8.57.1)
-      express: 4.22.1
-      fs-extra: 11.3.2
-      git-url-parse: 15.0.0
-      glob: 7.2.3
-      global-agent: 3.0.0
-      globby: 11.1.0
-      handlebars: 4.7.8
-      html-webpack-plugin: 5.6.5(@rspack/core@1.6.7(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      inquirer: 8.2.7(@types/node@25.0.0)
-      jest: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
-      jest-cli: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
-      jest-css-modules: 2.1.0
-      jest-environment-jsdom: 29.7.0
-      jest-runtime: 29.7.0
-      json-schema: 0.4.0
-      lodash: 4.17.23
-      minimatch: 9.0.5
-      node-stdlib-browser: 1.3.1
-      npm-packlist: 5.1.3
-      ora: 5.4.1
-      p-queue: 6.6.2
-      pirates: 4.0.7
-      postcss: 8.5.6
-      process: 0.11.10
-      raw-loader: 4.0.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      react-dev-utils: 12.0.1(eslint@8.57.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      react-refresh: 0.17.0
-      recursive-readdir: 2.2.3
-      replace-in-file: 7.2.0
-      rollup: 4.53.3
-      rollup-plugin-dts: 6.3.0(rollup@4.53.3)(typescript@5.9.3)
-      rollup-plugin-esbuild: 6.2.1(esbuild@0.25.12)(rollup@4.53.3)
-      rollup-plugin-postcss: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
-      rollup-pluginutils: 2.8.2
-      semver: 7.7.3
-      style-loader: 3.3.4(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      sucrase: 3.35.1
-      swc-loader: 0.2.6(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      tar: 7.5.7
-      ts-checker-rspack-plugin: 1.2.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(typescript@5.9.3)
-      ts-morph: 24.0.0
-      undici: 7.18.2
-      util: 0.12.5
-      yaml: 2.8.2
-      yargs: 16.2.0
-      yml-loader: 2.1.0
-      yn: 4.0.0
-      zod: 3.25.76
-      zod-validation-error: 3.5.4(zod@3.25.76)
-    optionalDependencies:
-      '@module-federation/enhanced': 0.9.1(@rspack/core@1.6.7(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      terser-webpack-plugin: 5.3.15(@swc/core@1.15.3(@swc/helpers@0.5.17))(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-      webpack: 5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17))
-      webpack-dev-server: 5.2.2(webpack@5.96.1(@swc/core@1.15.3(@swc/helpers@0.5.17)))
-    transitivePeerDependencies:
-      - '@swc/wasm'
-      - '@types/express'
-      - '@types/node'
-      - babel-plugin-macros
-      - bufferutil
-      - canvas
-      - debug
-      - encoding
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - node-notifier
-      - supports-color
-      - ts-node
-      - typescript
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-
   '@backstage/config-loader@1.10.6(@swc/core@1.15.3(@swc/helpers@0.5.17))':
     dependencies:
       '@backstage/cli-common': 0.1.17
@@ -11723,7 +11890,7 @@ snapshots:
       '@backstage/errors': 1.2.7
       '@backstage/types': 1.2.2
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
+      ajv: 8.18.0
       chokidar: 3.6.0
       fs-extra: 11.3.2
       json-schema: 0.4.0
@@ -11732,6 +11899,27 @@ snapshots:
       lodash: 4.17.23
       minimist: 1.2.8
       typescript-json-schema: 0.65.1(@swc/core@1.15.3(@swc/helpers@0.5.17))
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+
+  '@backstage/config-loader@1.10.7(@swc/core@1.15.3(@swc/helpers@0.5.17))':
+    dependencies:
+      '@backstage/cli-common': 0.1.17
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.2
+      '@types/json-schema': 7.0.15
+      ajv: 8.18.0
+      chokidar: 3.6.0
+      fs-extra: 11.3.2
+      json-schema: 0.4.0
+      json-schema-merge-allof: 0.8.1
+      json-schema-traverse: 1.0.0
+      lodash: 4.17.23
+      minimist: 1.2.8
+      typescript-json-schema: 0.67.1(@swc/core@1.15.3(@swc/helpers@0.5.17))
       yaml: 2.8.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -12030,6 +12218,22 @@ snapshots:
       - encoding
       - supports-color
 
+  '@backstage/integration@1.19.2':
+    dependencies:
+      '@azure/identity': 4.13.0
+      '@azure/storage-blob': 12.29.1
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+      '@octokit/auth-app': 4.0.13
+      '@octokit/rest': 19.0.13
+      cross-fetch: 4.1.0
+      git-url-parse: 15.0.0
+      lodash: 4.17.23
+      luxon: 3.7.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@backstage/plugin-app@0.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@backstage/core-components': 0.18.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -12059,9 +12263,37 @@ snapshots:
       - react-native
       - supports-color
 
+  '@backstage/plugin-auth-node@0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/catalog-client': 1.12.1
+      '@backstage/catalog-model': 1.7.6
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.2
+      '@types/express': 4.17.25
+      '@types/passport': 1.0.17
+      express: 4.22.1
+      jose: 5.10.0
+      lodash: 4.17.23
+      passport: 0.7.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
   '@backstage/plugin-auth-node@0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/catalog-client': 1.12.1
       '@backstage/catalog-model': 1.7.6
       '@backstage/config': 1.3.6
@@ -12095,15 +12327,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@backstage/plugin-catalog-node@1.20.0(pg@8.16.3)':
+  '@backstage/plugin-catalog-node@1.20.1(better-sqlite3@12.5.0)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(pg@8.16.3)
       '@backstage/catalog-client': 1.12.1
       '@backstage/catalog-model': 1.7.6
       '@backstage/errors': 1.2.7
       '@backstage/plugin-catalog-common': 1.1.7
       '@backstage/plugin-permission-common': 0.9.3
-      '@backstage/plugin-permission-node': 0.10.6(pg@8.16.3)
+      '@backstage/plugin-permission-node': 0.10.9(better-sqlite3@12.5.0)(pg@8.16.3)
       '@backstage/types': 1.2.2
       lodash: 4.17.23
       yaml: 2.8.2
@@ -12162,7 +12394,7 @@ snapshots:
 
   '@backstage/plugin-events-node@0.4.17(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/errors': 1.2.7
       '@backstage/types': 1.2.2
       '@types/content-type': 1.1.9
@@ -12170,6 +12402,28 @@ snapshots:
       content-type: 1.0.5
       cross-fetch: 4.1.0
       express: 4.21.2
+      uri-template: 2.0.0
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@backstage/plugin-events-node@0.4.18(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.2
+      '@types/content-type': 1.1.9
+      '@types/express': 4.17.25
+      content-type: 1.0.5
+      cross-fetch: 4.1.0
+      express: 4.22.1
       uri-template: 2.0.0
     transitivePeerDependencies:
       - better-sqlite3
@@ -12194,9 +12448,21 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@backstage/plugin-permission-common@0.9.5':
+    dependencies:
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+      '@backstage/types': 1.2.2
+      cross-fetch: 4.1.0
+      uuid: 11.1.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+
   '@backstage/plugin-permission-node@0.10.6(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
       '@backstage/plugin-auth-node': 0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
@@ -12217,18 +12483,41 @@ snapshots:
       - supports-color
       - tedious
 
-  '@backstage/plugin-permission-node@0.10.6(pg@8.16.3)':
+  '@backstage/plugin-permission-node@0.10.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)':
     dependencies:
-      '@backstage/backend-plugin-api': 1.5.0(pg@8.16.3)
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
       '@backstage/config': 1.3.6
       '@backstage/errors': 1.2.7
-      '@backstage/plugin-auth-node': 0.6.9(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
-      '@backstage/plugin-permission-common': 0.9.3
+      '@backstage/plugin-auth-node': 0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-permission-common': 0.9.5
       '@types/express': 4.17.25
-      express: 4.21.2
-      express-promise-router: 4.1.1(@types/express@4.17.25)(express@4.21.2)
+      express: 4.22.1
+      express-promise-router: 4.1.1(@types/express@4.17.25)(express@4.22.1)
       zod: 3.25.76
-      zod-to-json-schema: 3.25.0(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - encoding
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@backstage/plugin-permission-node@0.10.9(better-sqlite3@12.5.0)(pg@8.16.3)':
+    dependencies:
+      '@backstage/backend-plugin-api': 1.6.2(better-sqlite3@12.5.0)(pg@8.16.3)
+      '@backstage/config': 1.3.6
+      '@backstage/errors': 1.2.7
+      '@backstage/plugin-auth-node': 0.6.12(better-sqlite3@12.5.0)(mysql2@3.15.3)(pg@8.16.3)
+      '@backstage/plugin-permission-common': 0.9.5
+      '@types/express': 4.17.25
+      express: 4.22.1
+      express-promise-router: 4.1.1(@types/express@4.17.25)(express@4.22.1)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - better-sqlite3
       - encoding
@@ -12563,7 +12852,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.12.6
+      ajv: 8.18.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
@@ -12577,7 +12866,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 8.18.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
@@ -12696,19 +12985,19 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/external-editor@1.0.3(@types/node@18.19.130)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 18.19.130
+
   '@inquirer/external-editor@1.0.3(@types/node@24.10.3)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
       '@types/node': 24.10.3
-
-  '@inquirer/external-editor@1.0.3(@types/node@25.0.0)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.0
-    optionalDependencies:
-      '@types/node': 25.0.0
 
   '@internationalized/date@3.10.0':
     dependencies:
@@ -12770,7 +13059,7 @@ snapshots:
       jest-util: 30.2.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12784,7 +13073,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12805,7 +13094,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12819,7 +13108,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15844,7 +16133,7 @@ snapshots:
 
   '@types/node-forge@1.3.14':
     dependencies:
-      '@types/node': 25.0.0
+      '@types/node': 24.10.3
 
   '@types/node@12.20.55': {}
 
@@ -16375,27 +16664,20 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
-  ajv-keywords@3.5.2(ajv@6.12.6):
+  ajv-keywords@3.5.2(ajv@8.18.0):
     dependencies:
-      ajv: 6.12.6
+      ajv: 8.18.0
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
-  ajv@6.12.6:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -17319,13 +17601,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17334,13 +17616,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -18175,6 +18457,17 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.49.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      jest: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.49.0(eslint@8.57.1)(typescript@5.9.3)
@@ -18182,17 +18475,6 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       jest: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@28.14.0(@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.49.0(eslint@8.57.1)(typescript@5.9.3)
-      eslint: 8.57.1
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      jest: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18315,7 +18597,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
+      ajv: 8.18.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -18362,7 +18644,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 8.18.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -18493,9 +18775,22 @@ snapshots:
     optionalDependencies:
       '@types/express': 4.17.25
 
+  express-promise-router@4.1.1(@types/express@4.17.25)(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      is-promise: 4.0.0
+      lodash.flattendeep: 4.4.0
+      methods: 1.1.2
+    optionalDependencies:
+      '@types/express': 4.17.25
+
   express-rate-limit@7.5.1(express@4.21.2):
     dependencies:
       express: 4.21.2
+
+  express-rate-limit@7.5.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
 
   express@4.21.2:
     dependencies:
@@ -19394,9 +19689,9 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  inquirer@8.2.7(@types/node@24.10.3):
+  inquirer@8.2.7(@types/node@18.19.130):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@24.10.3)
+      '@inquirer/external-editor': 1.0.3(@types/node@18.19.130)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -19414,9 +19709,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  inquirer@8.2.7(@types/node@25.0.0):
+  inquirer@8.2.7(@types/node@24.10.3):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@25.0.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.3)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -19802,6 +20097,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
@@ -19812,25 +20126,6 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19859,6 +20154,68 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-config@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 18.19.130
+      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.3
+      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
@@ -19886,68 +20243,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.3
       ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.10.3
-      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.0.0
-      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -20440,24 +20735,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.0.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@24.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -20546,8 +20841,6 @@ snapshots:
       compute-lcm: 1.1.2
       json-schema-compare: 0.2.2
       lodash: 4.17.23
-
-  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -21889,6 +22182,14 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.5.6
+      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)
+
   postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
       lilconfig: 2.1.0
@@ -21896,14 +22197,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)
-
-  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 1.10.2
-    optionalDependencies:
-      postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)
 
   postcss-merge-longhand@5.1.7(postcss@8.5.6):
     dependencies:
@@ -22242,7 +22535,7 @@ snapshots:
 
   rate-limit-redis@4.3.1(express-rate-limit@7.5.1(express@4.21.2)):
     dependencies:
-      express-rate-limit: 7.5.1(express@4.21.2)
+      express-rate-limit: 7.5.1(express@4.22.1)
 
   raw-body@2.5.2:
     dependencies:
@@ -22888,6 +23181,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      chalk: 4.1.2
+      concat-with-sourcemaps: 1.1.0
+      cssnano: 5.1.15(postcss@8.5.6)
+      import-cwd: 3.0.0
+      p-queue: 6.6.2
+      pify: 5.0.0
+      postcss: 8.5.6
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3))
+      postcss-modules: 4.3.1(postcss@8.5.6)
+      promise.series: 0.2.0
+      resolve: 1.22.11
+      rollup-pluginutils: 2.8.2
+      safe-identifier: 0.4.2
+      style-inject: 0.3.0
+    transitivePeerDependencies:
+      - ts-node
+
   rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3)):
     dependencies:
       chalk: 4.1.2
@@ -22898,25 +23210,6 @@ snapshots:
       pify: 5.0.0
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3))
-      postcss-modules: 4.3.1(postcss@8.5.6)
-      promise.series: 0.2.0
-      resolve: 1.22.11
-      rollup-pluginutils: 2.8.2
-      safe-identifier: 0.4.2
-      style-inject: 0.3.0
-    transitivePeerDependencies:
-      - ts-node
-
-  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3)):
-    dependencies:
-      chalk: 4.1.2
-      concat-with-sourcemaps: 1.1.0
-      cssnano: 5.1.15(postcss@8.5.6)
-      import-cwd: 3.0.0
-      p-queue: 6.6.2
-      pify: 5.0.0
-      postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3))
       postcss-modules: 4.3.1(postcss@8.5.6)
       promise.series: 0.2.0
       resolve: 1.22.11
@@ -23018,21 +23311,21 @@ snapshots:
   schema-utils@2.7.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
+      ajv: 8.18.0
+      ajv-keywords: 3.5.2(ajv@8.18.0)
 
   schema-utils@3.3.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
+      ajv: 8.18.0
+      ajv-keywords: 3.5.2(ajv@8.18.0)
 
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   screenfull@5.2.0: {}
 
@@ -23859,14 +24152,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
 
-  ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.10.3
+      '@types/node': 18.19.130
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -23880,14 +24173,14 @@ snapshots:
       '@swc/core': 1.15.3(@swc/helpers@0.5.17)
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@25.0.0)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@24.10.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.0.0
+      '@types/node': 24.10.3
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -23999,6 +24292,21 @@ snapshots:
       safe-stable-stringify: 2.5.0
       ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.5.4)
       typescript: 5.5.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+
+  typescript-json-schema@0.67.1(@swc/core@1.15.3(@swc/helpers@0.5.17)):
+    dependencies:
+      '@types/json-schema': 7.0.15
+      '@types/node': 18.19.130
+      glob: 7.2.3
+      path-equal: 1.2.5
+      safe-stable-stringify: 2.5.0
+      ts-node: 10.9.2(@swc/core@1.15.3(@swc/helpers@0.5.17))(@types/node@18.19.130)(typescript@5.5.4)
+      typescript: 5.5.4
+      vm2: 3.10.4
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -24131,10 +24439,6 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
-
   uri-template@2.0.0:
     dependencies:
       pct-encode: 1.0.3
@@ -24240,6 +24544,11 @@ snapshots:
       vfile-message: 3.1.4
 
   vm-browserify@1.1.2: {}
+
+  vm2@3.10.4:
+    dependencies:
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
 
   w3c-xmlserializer@4.0.0:
     dependencies:
@@ -24640,7 +24949,15 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 


### PR DESCRIPTION
### Changes

- Upgrade @backstage/backend-plugin-api from ^1.5.0 to ^1.6.2 to fix SNYK-JS-BACKSTAGEBACKENDPLUGINAPI-15054291 (Symlink Following, High)
- Upgrade @backstage/backend-defaults from ^0.13.2 to ^0.15.1
- Upgrade @backstage/plugin-catalog-node from ^1.20.0 to ^1.20.1
- Add pnpm override for ajv to 8.18.0 to fix SNYK-JS-AJV-15274295 (ReDoS, High)

### Notes
Note that this involves upgrading Backstage core api packages. The most noteable one is the major zod bump. You have a pinned version of zod (v3) so this should not affect your plugin.
  