### PR TITLE
feat: add wiz.io/resource-tags annotation support for entity-level flltering

### DIFF
--- a/plugins/backstage-plugin-wiz-backend/src/routes/Handlers.ts
+++ b/plugins/backstage-plugin-wiz-backend/src/routes/Handlers.ts
@@ -22,8 +22,15 @@ export async function handleGetIssues(
     if (queryParams.relatedEntity) {
       try {
         const relatedEntity = JSON.parse(String(queryParams.relatedEntity));
+        const relatedEntityFilter: Record<string, unknown> = {};
         if (relatedEntity.ids) {
-          filters.relatedEntity = { ids: relatedEntity.ids };
+          relatedEntityFilter.ids = relatedEntity.ids;
+        }
+        if (relatedEntity.tag) {
+          relatedEntityFilter.tag = relatedEntity.tag;
+        }
+        if (Object.keys(relatedEntityFilter).length > 0) {
+          filters.relatedEntity = relatedEntityFilter;
         }
       } catch (error) {
         throw new WizError(
@@ -67,10 +74,20 @@ export async function handleGetVulnerabilities(
       filters.assetId = queryParams.assetId;
     }
 
-    if (queryParams.assetTags?.containsAny) {
-      filters.assetTags = {
-        containsAny: queryParams.assetTags.containsAny,
-      };
+    if (queryParams.assetTags) {
+      try {
+        const parsedAssetTags = JSON.parse(String(queryParams.assetTags));
+        if (parsedAssetTags?.containsAny) {
+          filters.assetTags = { containsAny: parsedAssetTags.containsAny };
+        }
+      } catch (error) {
+        throw new WizError(
+          WizErrorType.INVALID_REQUEST,
+          'Invalid assetTags format',
+          400,
+          error,
+        );
+      }
     }
 
     if (queryParams.vulnerabilityExternalId) {
@@ -104,8 +121,15 @@ export async function handleGetIssuesStats(
     if (queryParams.relatedEntity) {
       try {
         const relatedEntity = JSON.parse(String(queryParams.relatedEntity));
+        const relatedEntityFilter: Record<string, unknown> = {};
         if (relatedEntity.ids) {
-          filters.relatedEntity = { ids: relatedEntity.ids };
+          relatedEntityFilter.ids = relatedEntity.ids;
+        }
+        if (relatedEntity.tag) {
+          relatedEntityFilter.tag = relatedEntity.tag;
+        }
+        if (Object.keys(relatedEntityFilter).length > 0) {
+          filters.relatedEntity = relatedEntityFilter;
         }
       } catch (error) {
         throw new WizError(

--- a/plugins/backstage-plugin-wiz/src/components/App.tsx
+++ b/plugins/backstage-plugin-wiz/src/components/App.tsx
@@ -7,12 +7,13 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { useEffect, useState } from 'react';
 import { WizAPI, wizApiRef } from '../api';
-import { EntityIds, IdsResult } from '../types';
+import { EntityIds, EntityTag, IdsResult } from '../types';
 import {
   WIZ_ASSET_ANNOTATION,
   WIZ_EXTERNAL_ASSET_ANNOTATION,
   WIZ_PROJECT_ANNOTATION,
   WIZ_REPO_ANNOTATION,
+  WIZ_TAGS_ANNOTATION,
 } from '../utils/constants';
 import { Overview } from './Overview';
 
@@ -61,8 +62,32 @@ async function getVersionControlIds(
   }
 }
 
+/**
+ * Parses the wiz.io/resource-tags annotation value into EntityTag objects.
+ * Supports comma-separated "key=value" pairs.
+ * Example: "custom/env=prod,custom/team=backend" → [{key:"custom/env",value:"prod"},{key:"custom/team",value:"backend"}]
+ */
+function parseResourceTags(annotation: string | undefined): EntityTag[] {
+  if (!annotation) return [];
+  return annotation
+    .split(',')
+    .map(tag => tag.trim())
+    .filter(tag => tag.includes('='))
+    .map(tag => {
+      const eqIndex = tag.indexOf('=');
+      return {
+        key: tag.substring(0, eqIndex).trim(),
+        value: tag.substring(eqIndex + 1).trim(),
+      };
+    })
+    .filter(tag => tag.key && tag.value);
+}
+
 export const isWizAvailable = (entity: Entity) => {
-  return Boolean(entity?.metadata.annotations?.[WIZ_PROJECT_ANNOTATION]);
+  return Boolean(
+    entity?.metadata.annotations?.[WIZ_PROJECT_ANNOTATION] ||
+      entity?.metadata.annotations?.[WIZ_TAGS_ANNOTATION],
+  );
 };
 
 export const areWizAnnotationsMissing = (entity: Entity) => {
@@ -73,6 +98,7 @@ export const areWizAnnotationsMissing = (entity: Entity) => {
     WIZ_ASSET_ANNOTATION,
     WIZ_EXTERNAL_ASSET_ANNOTATION,
     WIZ_REPO_ANNOTATION,
+    WIZ_TAGS_ANNOTATION,
   ];
 
   const hasRequiredAnnotation = requiredAnnotations.some(
@@ -92,6 +118,7 @@ const MainPage = () => {
     versionControlIds: [],
     directAssetIds: [],
     projectIds: [],
+    entityTags: [],
   });
 
   useEffect(() => {
@@ -143,12 +170,18 @@ const MainPage = () => {
           );
         }
 
+        // Parse resource tags
+        const entityTags = parseResourceTags(
+          annotations[WIZ_TAGS_ANNOTATION],
+        );
+
         // Set all IDs
         setEntityIds({
           cloudResourceIds: cloudResourcesResult.ids || [],
           versionControlIds: versionControlResult.ids || [],
           directAssetIds,
           projectIds,
+          entityTags,
         });
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to fetch IDs'));
@@ -196,7 +229,7 @@ const MainPage = () => {
       return (
         <EmptyState
           title="No Resources Found"
-          description="No Wiz resources and projects, repositories or cloud assets were found for this entity."
+          description="No Wiz resources, projects, repositories, cloud assets or resource tags were found for this entity."
           missing="info"
         />
       );

--- a/plugins/backstage-plugin-wiz/src/components/issues/filters.ts
+++ b/plugins/backstage-plugin-wiz/src/components/issues/filters.ts
@@ -1,9 +1,12 @@
-import { EntityIds } from '../../types';
+import { EntityIds, EntityTag } from '../../types';
 
 export type Filters = {
   project?: string[];
   relatedEntity?: {
     ids?: string[];
+    tag?: {
+      containsAll: EntityTag[];
+    };
   };
   search?: string;
 };
@@ -35,6 +38,14 @@ export const buildFilterBy = (
     if (allIds.length > 0) {
       filter.relatedEntity = { ids: allIds };
     }
+  }
+
+  // Add resource tag filtering
+  if (entityIds.entityTags.length > 0) {
+    filter.relatedEntity = {
+      ...(filter.relatedEntity || {}),
+      tag: { containsAll: entityIds.entityTags },
+    };
   }
 
   if (searchText?.trim()) {

--- a/plugins/backstage-plugin-wiz/src/components/vulnerabilities/filters.ts
+++ b/plugins/backstage-plugin-wiz/src/components/vulnerabilities/filters.ts
@@ -1,9 +1,12 @@
-import { EntityIds } from '../../types';
+import { EntityIds, EntityTag } from '../../types';
 
 export type Filters = {
   projectId?: string[];
   assetId?: string[];
   vulnerabilityExternalId?: string[];
+  assetTags?: {
+    containsAny: EntityTag[];
+  };
 };
 
 export const buildFilterBy = (
@@ -33,6 +36,11 @@ export const buildFilterBy = (
     if (allIds.length > 0) {
       filter.assetId = allIds;
     }
+  }
+
+  // Add resource tag filtering
+  if (entityIds.entityTags.length > 0) {
+    filter.assetTags = { containsAny: entityIds.entityTags };
   }
 
   if (searchText?.trim()) {

--- a/plugins/backstage-plugin-wiz/src/index.ts
+++ b/plugins/backstage-plugin-wiz/src/index.ts
@@ -2,4 +2,7 @@ export { backstagePluginWizPlugin, BackstagePluginWizPage } from './plugin';
 export * from './plugin';
 export * from './api';
 export { App as Router, isWizAvailable } from './components/App';
-export { WIZ_PROJECT_ANNOTATION } from './utils/constants';
+export {
+  WIZ_PROJECT_ANNOTATION,
+  WIZ_TAGS_ANNOTATION,
+} from './utils/constants';

--- a/plugins/backstage-plugin-wiz/src/types/index.ts
+++ b/plugins/backstage-plugin-wiz/src/types/index.ts
@@ -145,9 +145,15 @@ export interface IdsResult {
   error?: Error;
 }
 
+export interface EntityTag {
+  key: string;
+  value: string;
+}
+
 export interface EntityIds {
   cloudResourceIds: string[];
   versionControlIds: string[];
   directAssetIds: string[];
   projectIds: string[];
+  entityTags: EntityTag[];
 }

--- a/plugins/backstage-plugin-wiz/src/utils/constants.ts
+++ b/plugins/backstage-plugin-wiz/src/utils/constants.ts
@@ -2,3 +2,4 @@ export const WIZ_PROJECT_ANNOTATION = 'wiz.io/project-id';
 export const WIZ_ASSET_ANNOTATION = 'wiz.io/asset-id';
 export const WIZ_EXTERNAL_ASSET_ANNOTATION = 'wiz.io/external-asset-id';
 export const WIZ_REPO_ANNOTATION = 'wiz.io/repository-external-id';
+export const WIZ_TAGS_ANNOTATION = 'wiz.io/resource-tags';


### PR DESCRIPTION

- Add WIZ_TAGS_ANNOTATION constant ('wiz.io/resource-tags')
- Add IssueEntityTag type and entityTags field to EntityIds
- Parse 'key=value' tags from entity annotation in App.tsx
- isWizAvailable returns true when either project-id or resource-tags present
- Issues filter: use relatedEntity.tag.containsAll (correct Wiz GraphQL schema path)
- Vulnerabilities filter: use assetTags.containsAny
- Backend Handlers: pass through relatedEntity.tag fields + JSON.parse assetTags
- Export WIZ_TAGS_ANNOTATION from plugin index